### PR TITLE
Fix compiler error (Swift 5)

### DIFF
--- a/framework/SwiftOCR/SwiftOCRTraining.swift
+++ b/framework/SwiftOCR/SwiftOCRTraining.swift
@@ -73,7 +73,12 @@ open class SwiftOCRTraining {
         }
         
         let randomFloat: (CGFloat) -> CGFloat = { modi in
-            return  (0 - modi) + CGFloat(arc4random()) / CGFloat(UINT32_MAX) * (modi * 2)
+
+            let x = CGFloat(arc4random())
+            let y = (0 - modi) + x
+            let z = CGFloat(UINT32_MAX) * (modi * 2)
+      
+            return y / z
         }
         
         //Font
@@ -219,7 +224,12 @@ open class SwiftOCRTraining {
         var trainingSet = [([Float],[Float])]()
         
         let randomFloat: (CGFloat) -> CGFloat = { modi in
-            return  (0 - modi) + CGFloat(arc4random()) / CGFloat(UINT32_MAX) * (modi * 2)
+
+            let x = CGFloat(arc4random())
+            let y = (0 - modi) + x
+            let z = CGFloat(UINT32_MAX) * (modi * 2)
+      
+            return y / z
         }
         
         for (image, characters) in images {


### PR DESCRIPTION
 'compiler is unable to type-check this expression in reasonable time...' for the randomFloat variable. I fixed this by dividing the return value into three sub sections x, y, and z.